### PR TITLE
Portable va_list changes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,8 +61,8 @@ set_target_properties(libffi PROPERTIES
 #clean up libffi's non-compliant build artifacts
 ExternalProject_Get_Property(ffi SOURCE_DIR)
 add_custom_command(
-    TARGET ffi POST_BUILD
-    COMMAND git clean -f
+    TARGET ffi PRE_BUILD
+    COMMAND git clean -x -d -f
     COMMAND git reset --hard
     WORKING_DIRECTORY ${SOURCE_DIR}
     COMMENT "Cleaning libffi directory..."
@@ -99,8 +99,8 @@ set_target_properties(liblzma PROPERTIES
 #clean up liblzma's non-compliant build artifacts
 ExternalProject_Get_Property(lzma SOURCE_DIR)
 add_custom_command(
-    TARGET lzma POST_BUILD
-    COMMAND git clean -f
+    TARGET lzma PRE_BUILD
+    COMMAND git clean -x -d -f
     COMMAND git reset --hard
     WORKING_DIRECTORY ${SOURCE_DIR}
     COMMENT "Cleaning xz directory..."
@@ -132,6 +132,16 @@ file(MAKE_DIRECTORY ${LIBUNWIND_INSTALL_DIR}/include)
 set_target_properties(libunwind PROPERTIES
     IMPORTED_LOCATION ${INSTALL_DIR}/lib/libunwind.a
     INTERFACE_INCLUDE_DIRECTORIES ${LIBUNWIND_INSTALL_DIR}/include
+)
+
+#clean up libunwind's non-compliant build artifacts
+ExternalProject_Get_Property(unwind SOURCE_DIR)
+add_custom_command(
+        TARGET unwind PRE_BUILD
+        COMMAND git clean -x -d -f
+        COMMAND git reset --hard
+        WORKING_DIRECTORY ${SOURCE_DIR}
+        COMMENT "Cleaning unwind directory..."
 )
 
 #fake-jni

--- a/examples/src/agent.cpp
+++ b/examples/src/agent.cpp
@@ -4,17 +4,17 @@
 
 extern "C" {
  //Example dynamic Agent linkage
- jint Agent_OnLoad(JavaVM *vm, char *options, void *reserved) {
+ jint Agent_OnLoad(JavaVM * vm, char * options, void * reserved) {
   std::cout << "Cold Start Agent Hello World!" << std::endl;
   return JNI_OK;
  }
 
- jint Agent_OnAttach(JavaVM *vm, char *options, void *reserved) {
+ jint Agent_OnAttach(JavaVM * vm, char * options, void * reserved) {
   std::cout << "Live Attach Agent Hello World!" << std::endl;
   return JNI_OK;
  }
 
- void Agent_OnUnload(JavaVM *vm) {
+ void Agent_OnUnload(JavaVM * vm) {
   std::cout << "Agent Goodbye World!" << std::endl;
  }
 }

--- a/examples/src/jni.cpp
+++ b/examples/src/jni.cpp
@@ -4,12 +4,12 @@
 
 extern "C" {
  //Example dynamic JNI linkage
- jint JNI_OnLoad(JavaVM *vm, void *reserved) {
+ jint JNI_OnLoad(JavaVM * vm, void * reserved) {
   std::cout << "JNI Hello World!" << std::endl;
   return JNI_OK;
  }
 
- void JNI_OnUnload(JavaVM *vm, void *reserved) {
+ void JNI_OnUnload(JavaVM * vm, void * reserved) {
   std::cout << "JNI Goodbye World!" << std::endl;
  }
 }

--- a/examples/src/main.cpp
+++ b/examples/src/main.cpp
@@ -79,6 +79,10 @@ BEGIN_NATIVE_DESCRIPTOR(ExampleClass)
  {Constructor<ExampleClass, JDouble, ExampleClass *> {}}
 END_NATIVE_DESCRIPTOR
 
+static void bruh(JNIEnv *env, jobject clazzOrInst, JDouble value) {
+ printf("Value: %f\n", value);
+}
+
 //fake-jni in action
 int main(int argc, char **argv) {
  //Make a JString

--- a/include/fake-jni/internal/meta/meta.h
+++ b/include/fake-jni/internal/meta/meta.h
@@ -112,10 +112,6 @@ namespace FakeJni {
   template<typename T>
   class BaseDefined<T, CX::void_a<T::base>>;
 
-  struct member_ptr_align_t {
-   void * low, * high;
-  } __attribute__((packed));
-
   template<unsigned N>
   struct arbitrary_align_t {
    unsigned char data[N];

--- a/include/fake-jni/jvm.h
+++ b/include/fake-jni/jvm.h
@@ -1741,23 +1741,31 @@ namespace FakeJni {
   }
  }
 
- //JValueArgResolver for JObject derived classes (see meta/method.h)
+ //JValueUtil for JObject derived classes (see meta/method.h)
  namespace _CX {
   template<typename T>
-  class JValueArgResolver<true, T> {
+  class JValueUtil<T, true> {
 
   public:
    inline static constexpr const bool isRegisteredResolver = true;
    using componentType = typename ComponentTypeResolver<T*>::type;
 
+   static_assert(__is_base_of(JObject, componentType), "Illegal JNI function parameter type!");
+
    [[gnu::always_inline]]
-   inline static componentType* getAArg(jvalue *values) {
-    static_assert(__is_base_of(JObject, componentType), "Illegal JNI function parameter type!");
+   inline static componentType * getAArg(jvalue * values) {
     if constexpr(CastDefined<componentType>::value) {
      return componentType::cast::cast((JObject*)values->l);
     } else {
      return (componentType *)values->l;
     }
+   }
+
+   [[gnu::always_inline nodiscard]]
+   inline static jvalue makeAArg(componentType * value) {
+    jvalue jv;
+    jv.l = value;
+    return jv;
    }
   };
  }

--- a/include/fake-jni/jvm.h
+++ b/include/fake-jni/jvm.h
@@ -11,6 +11,7 @@
 #include <cx/idioms.h>
 #include <cx/strings.h>
 #include <cx/unsafe.h>
+#include <cx/vararg.h>
 
 #include <ffi.h>
 
@@ -62,11 +63,7 @@ static_assert(\
 #define _INTERNAL_INVOKE_VA_ARG(type, ffi_type) \
 if (ffi_arg_t == &ffi_type) {\
  auto *value = values[i + 2];\
- if constexpr(sizeof(type) > sizeof(int)) {\
-  *((type *)value) = (type)va_arg(args, double);\
- } else {\
-  *((type *)value) = (type)va_arg(args, int);\
- }\
+ *((type *)value) = CX::safe_va_arg<type>(args);\
  continue;\
 }
 
@@ -248,7 +245,7 @@ namespace FakeJni {
   virtual jboolean isSameObject(jobject, jobject) const;
   virtual jobject allocObject(jclass) const;
 //  virtual jobject newObject(jclass, jmethodID, ...) const;
-  virtual jobject newObjectV(jclass, jmethodID, va_list) const;
+  virtual jobject newObjectV(jclass, jmethodID, CX::va_list_t&) const;
   virtual jobject newObjectA(jclass, jmethodID, const jvalue *) const;
   virtual jclass getObjectClass(jobject) const;
   virtual jboolean isInstanceOf(jobject, jclass) const;
@@ -275,95 +272,95 @@ namespace FakeJni {
   //jni/native/method.cpp
   virtual jmethodID getMethodID(jclass, const char *, const char *) const;
 //  virtual jobject callObjectMethod(jobject, jmethodID, ...) const;
-  virtual jobject callObjectMethodV(jobject, jmethodID, va_list) const;
+  virtual jobject callObjectMethodV(jobject, jmethodID, CX::va_list_t&) const;
   virtual jobject callObjectMethodA(jobject, jmethodID, const jvalue *) const;
 //  virtual jboolean callBooleanMethod(jobject, jmethodID, ...) const;
-  virtual jboolean callBooleanMethodV(jobject, jmethodID, va_list) const;
+  virtual jboolean callBooleanMethodV(jobject, jmethodID, CX::va_list_t&) const;
   virtual jboolean callBooleanMethodA(jobject, jmethodID, const jvalue *) const;
 //  virtual jbyte callByteMethod(jobject, jmethodID, ...) const;
-  virtual jbyte callByteMethodV(jobject, jmethodID, va_list) const;
+  virtual jbyte callByteMethodV(jobject, jmethodID, CX::va_list_t&) const;
   virtual jbyte callByteMethodA(jobject, jmethodID, const jvalue *) const;
 //  virtual jchar callCharMethod(jobject, jmethodID, ...) const;
-  virtual jchar callCharMethodV(jobject, jmethodID, va_list) const;
+  virtual jchar callCharMethodV(jobject, jmethodID, CX::va_list_t&) const;
   virtual jchar callCharMethodA(jobject, jmethodID, const jvalue *) const;
 //  virtual jshort callShortMethod(jobject, jmethodID, ...) const;
-  virtual jshort callShortMethodV(jobject, jmethodID, va_list) const;
+  virtual jshort callShortMethodV(jobject, jmethodID, CX::va_list_t&) const;
   virtual jshort callShortMethodA(jobject, jmethodID, const jvalue *) const;
 //  virtual jint callIntMethod(jobject, jmethodID, ...) const;
-  virtual jint callIntMethodV(jobject, jmethodID, va_list) const;
+  virtual jint callIntMethodV(jobject, jmethodID, CX::va_list_t&) const;
   virtual jint callIntMethodA(jobject, jmethodID, const jvalue *) const;
 //  virtual jlong callLongMethod(jobject, jmethodID, ...) const;
-  virtual jlong callLongMethodV(jobject, jmethodID, va_list) const;
+  virtual jlong callLongMethodV(jobject, jmethodID, CX::va_list_t&) const;
   virtual jlong callLongMethodA(jobject, jmethodID, const jvalue *) const;
 //  virtual jfloat callFloatMethod(jobject, jmethodID, ...) const;
-  virtual jfloat callFloatMethodV(jobject, jmethodID, va_list) const;
+  virtual jfloat callFloatMethodV(jobject, jmethodID, CX::va_list_t&) const;
   virtual jfloat callFloatMethodA(jobject, jmethodID, const jvalue *) const;
 //  virtual jdouble callDoubleMethod(jobject, jmethodID, ...) const;
-  virtual jdouble callDoubleMethodV(jobject, jmethodID, va_list) const;
+  virtual jdouble callDoubleMethodV(jobject, jmethodID, CX::va_list_t&) const;
   virtual jdouble callDoubleMethodA(jobject, jmethodID, const jvalue *) const;
 //  virtual void callVoidMethod(jobject, jmethodID, ...) const;
-  virtual void callVoidMethodV(jobject, jmethodID, va_list) const;
+  virtual void callVoidMethodV(jobject, jmethodID, CX::va_list_t&) const;
   virtual void callVoidMethodA(jobject, jmethodID, const jvalue *) const;
 //  virtual jobject callNonvirtualObjectMethod(jobject, jclass, jmethodID, ...) const;
-  virtual jobject callNonvirtualObjectMethodV(jobject, jclass, jmethodID, va_list) const;
+  virtual jobject callNonvirtualObjectMethodV(jobject, jclass, jmethodID, CX::va_list_t&) const;
   virtual jobject callNonvirtualObjectMethodA(jobject, jclass, jmethodID, const jvalue *) const;
 //  virtual jboolean callNonvirtualBooleanMethod(jobject, jclass, jmethodID, ...) const;
-  virtual jboolean callNonvirtualBooleanMethodV(jobject, jclass, jmethodID, va_list) const;
+  virtual jboolean callNonvirtualBooleanMethodV(jobject, jclass, jmethodID, CX::va_list_t&) const;
   virtual jboolean callNonvirtualBooleanMethodA(jobject, jclass, jmethodID, const jvalue *) const;
 //  virtual jbyte callNonvirtualByteMethod(jobject, jclass, jmethodID, ...) const;
-  virtual jbyte callNonvirtualByteMethodV(jobject, jclass, jmethodID, va_list) const;
+  virtual jbyte callNonvirtualByteMethodV(jobject, jclass, jmethodID, CX::va_list_t&) const;
   virtual jbyte callNonvirtualByteMethodA(jobject, jclass, jmethodID, const jvalue *) const;
 //  virtual jchar callNonvirtualCharMethod(jobject, jclass, jmethodID, ...) const;
-  virtual jchar callNonvirtualCharMethodV(jobject, jclass, jmethodID, va_list) const;
+  virtual jchar callNonvirtualCharMethodV(jobject, jclass, jmethodID, CX::va_list_t&) const;
   virtual jchar callNonvirtualCharMethodA(jobject, jclass, jmethodID, const jvalue *) const;
 //  virtual jshort callNonvirtualShortMethod(jobject, jclass, jmethodID, ...) const;
-  virtual jshort callNonvirtualShortMethodV(jobject, jclass, jmethodID, va_list) const;
+  virtual jshort callNonvirtualShortMethodV(jobject, jclass, jmethodID, CX::va_list_t&) const;
   virtual jshort callNonvirtualShortMethodA(jobject, jclass, jmethodID, const jvalue *) const;
 //  virtual jint callNonvirtualIntMethod(jobject, jclass, jmethodID, ...) const;
-  virtual jint callNonvirtualIntMethodV(jobject, jclass, jmethodID, va_list) const;
+  virtual jint callNonvirtualIntMethodV(jobject, jclass, jmethodID, CX::va_list_t&) const;
   virtual jint callNonvirtualIntMethodA(jobject, jclass, jmethodID, const jvalue *) const;
 //  virtual jlong callNonvirtualLongMethod(jobject, jclass, jmethodID, ...) const;
-  virtual jlong callNonvirtualLongMethodV(jobject, jclass, jmethodID, va_list) const;
+  virtual jlong callNonvirtualLongMethodV(jobject, jclass, jmethodID, CX::va_list_t&) const;
   virtual jlong callNonvirtualLongMethodA(jobject, jclass, jmethodID, const jvalue *) const;
 //  virtual jfloat callNonvirtualFloatMethod(jobject, jclass, jmethodID, ...) const;
-  virtual jfloat callNonvirtualFloatMethodV(jobject, jclass, jmethodID, va_list) const;
+  virtual jfloat callNonvirtualFloatMethodV(jobject, jclass, jmethodID, CX::va_list_t&) const;
   virtual jfloat callNonvirtualFloatMethodA(jobject, jclass, jmethodID, const jvalue *) const;
 //  virtual jdouble callNonvirtualDoubleMethod(jobject, jclass, jmethodID, ...) const;
-  virtual jdouble callNonvirtualDoubleMethodV(jobject, jclass, jmethodID, va_list) const;
+  virtual jdouble callNonvirtualDoubleMethodV(jobject, jclass, jmethodID, CX::va_list_t&) const;
   virtual jdouble callNonvirtualDoubleMethodA(jobject, jclass, jmethodID, const jvalue *) const;
 //  virtual void callNonvirtualVoidMethod(jobject, jclass, jmethodID, ...) const;
-  virtual void callNonvirtualVoidMethodV(jobject, jclass, jmethodID, va_list) const;
+  virtual void callNonvirtualVoidMethodV(jobject, jclass, jmethodID, CX::va_list_t&) const;
   virtual void callNonvirtualVoidMethodA(jobject, jclass, jmethodID, const jvalue *) const;
   virtual jmethodID getStaticMethodID(jclass, const char *, const char *) const;
 //  virtual jobject callStaticObjectMethod(jclass, jmethodID, ...) const;
-  virtual jobject callStaticObjectMethodV(jclass, jmethodID, va_list) const;
+  virtual jobject callStaticObjectMethodV(jclass, jmethodID, CX::va_list_t&) const;
   virtual jobject callStaticObjectMethodA(jclass, jmethodID, const jvalue *) const;
 //  virtual jboolean callStaticBooleanMethod(jclass, jmethodID, ...) const;
-  virtual jboolean callStaticBooleanMethodV(jclass, jmethodID, va_list) const;
+  virtual jboolean callStaticBooleanMethodV(jclass, jmethodID, CX::va_list_t&) const;
   virtual jboolean callStaticBooleanMethodA(jclass, jmethodID, const jvalue *) const;
 //  virtual jbyte callStaticByteMethod(jclass, jmethodID, ...) const;
-  virtual jbyte callStaticByteMethodV(jclass, jmethodID, va_list) const;
+  virtual jbyte callStaticByteMethodV(jclass, jmethodID, CX::va_list_t&) const;
   virtual jbyte callStaticByteMethodA(jclass, jmethodID, const jvalue *) const;
 //  virtual jchar callStaticCharMethod(jclass, jmethodID, ...) const;
-  virtual jchar callStaticCharMethodV(jclass, jmethodID, va_list) const;
+  virtual jchar callStaticCharMethodV(jclass, jmethodID, CX::va_list_t&) const;
   virtual jchar callStaticCharMethodA(jclass, jmethodID, const jvalue *) const;
 //  virtual jshort callStaticShortMethod(jclass, jmethodID, ...) const;
-  virtual jshort callStaticShortMethodV(jclass, jmethodID, va_list) const;
+  virtual jshort callStaticShortMethodV(jclass, jmethodID, CX::va_list_t&) const;
   virtual jshort callStaticShortMethodA(jclass, jmethodID, const jvalue *) const;
 //  virtual jint callStaticIntMethod(jclass, jmethodID, ...) const;
-  virtual jint callStaticIntMethodV(jclass, jmethodID, va_list) const;
+  virtual jint callStaticIntMethodV(jclass, jmethodID, CX::va_list_t&) const;
   virtual jint callStaticIntMethodA(jclass, jmethodID, const jvalue *) const;
 //  virtual jlong callStaticLongMethod(jclass, jmethodID, ...) const;
-  virtual jlong callStaticLongMethodV(jclass, jmethodID, va_list) const;
+  virtual jlong callStaticLongMethodV(jclass, jmethodID, CX::va_list_t&) const;
   virtual jlong callStaticLongMethodA(jclass, jmethodID, const jvalue *) const;
 //  virtual jfloat callStaticFloatMethod(jclass, jmethodID, ...) const;
-  virtual jfloat callStaticFloatMethodV(jclass, jmethodID, va_list) const;
+  virtual jfloat callStaticFloatMethodV(jclass, jmethodID, CX::va_list_t&) const;
   virtual jfloat callStaticFloatMethodA(jclass, jmethodID, const jvalue *) const;
 //  virtual jdouble callStaticDoubleMethod(jclass, jmethodID, ...) const;
-  virtual jdouble callStaticDoubleMethodV(jclass, jmethodID, va_list) const;
+  virtual jdouble callStaticDoubleMethodV(jclass, jmethodID, CX::va_list_t&) const;
   virtual jdouble callStaticDoubleMethodA(jclass, jmethodID, const jvalue *) const;
 //  virtual void callStaticVoidMethod(jclass, jmethodID, ...) const;
-  virtual void callStaticVoidMethodV(jclass, jmethodID, va_list) const;
+  virtual void callStaticVoidMethodV(jclass, jmethodID, CX::va_list_t&) const;
   virtual void callStaticVoidMethodA(jclass, jmethodID, const jvalue *) const;
 
   //jni/native/field.cpp
@@ -427,13 +424,21 @@ namespace FakeJni {
   virtual jobjectArray newObjectArray(jsize, jclass, jobject) const;
   virtual jobject getObjectArrayElement(jobjectArray, jsize) const;
   virtual void setObjectArrayElement(jobjectArray, jsize, jobject) const;
+  [[nodiscard]]
   virtual jbooleanArray newBooleanArray(jsize) const;
+  [[nodiscard]]
   virtual jbyteArray newByteArray(jsize) const;
+  [[nodiscard]]
   virtual jcharArray newCharArray(jsize) const;
+  [[nodiscard]]
   virtual jshortArray newShortArray(jsize) const;
+  [[nodiscard]]
   virtual jintArray newIntArray(jsize) const;
+  [[nodiscard]]
   virtual jlongArray newLongArray(jsize) const;
+  [[nodiscard]]
   virtual jfloatArray newFloatArray(jsize) const;
+  [[nodiscard]]
   virtual jdoubleArray newDoubleArray(jsize) const;
   virtual jboolean *getBooleanArrayElements(jbooleanArray, jboolean *) const;
   virtual jbyte *getByteArrayElements(jbyteArray, jboolean *) const;
@@ -859,8 +864,8 @@ namespace FakeJni {
 // class JMethodID final : public _jmethodID, private JNINativeMethod {
  class JMethodID final : public _jmethodID, public JNINativeMethod {
  public:
-  using static_func_t = void (* const)();
-  using member_func_t = void (_CX::AnyClass::* const)();
+  using static_func_t = void (*)();
+  using member_func_t = void (_CX::AnyClass::*)();
   using arbitrary_func_t = void * (*)(JNIEnv * env, jobject objOrInst, ...);
   using void_func_t = void (*)();
 
@@ -903,21 +908,30 @@ namespace FakeJni {
    };
   };
 
-  //Default case for va_list
-  //TODO this is nasty, there is no type checking for `T` on `JMethodID::invoke<R, T>` because of va_list
-  // fix this
-  template<typename>
-  [[gnu::always_inline]]
+  template<typename T>
+  [[gnu::always_inline nodiscard]]
   static_func_t getFunctionProxy() const {
-   return proxyFuncV;
+   using component_t = typename CX::ComponentTypeResolver<T>::type;
+   if (type == REGISTER_NATIVES_FUNC) {
+    throw std::runtime_error(
+     "FATAL: Internal error: JMethodID::getFunctionProxy<T> only accepts CX::va_list_t and jvalue as type parameters!"
+    );
+   } else {
+    if constexpr(CX::IsSame<component_t, CX::va_list_t>::value) {
+     return proxyFuncV;
+    } else if constexpr(CX::IsSame<component_t, jvalue>::value) {
+     return proxyFuncA;
+    }
+   }
   }
 
   static /*const*/ char * verifyName(const char * name);
   static /*const*/ char * verifySignature(const char * sig);
+  [[nodiscard]]
   static std::vector<ffi_type *> getFfiPrototype(const char * signature, const char * name);
 
   template<typename R, typename A>
-  R internalInvoke(const JavaVM * vm, void * clazzOrInst, A args) const;
+  R internalInvoke(const JavaVM * vm, void * clazzOrInst, A& args) const;
 
  public:
   const bool isArbitrary;
@@ -981,9 +995,9 @@ namespace FakeJni {
   bool operator ==(const JMethodID& mid) const noexcept;
   bool operator ==(JNINativeMethod*& mid) const;
   template<typename R, typename A>
-  R virtualInvoke(const JavaVM *vm, void *clazzOrInst, A args) const;
+  R virtualInvoke(const JavaVM *vm, void *clazzOrInst, A& args) const;
   template<typename R, typename A>
-  R nonVirtualInvoke(const JavaVM *vm, JClass *const clazz, void *const inst, A args) const;
+  R nonVirtualInvoke(const JavaVM *vm, JClass *const clazz, void *const inst, A& args) const;
   template<typename R>
   R invoke(const JavaVM * vm, const JObject * clazzOrInst, ...) const;
  };
@@ -1018,7 +1032,7 @@ namespace FakeJni {
    using JClassBreeder<T, nullptr>::JClassBreeder;
 
    template<typename A>
-   static JObject * constructorPredicate(const JavaVM * vm, const char * signature, A args);
+   static JObject * constructorPredicate(const JavaVM * vm, const char * signature, A& args);
 
    static constexpr void assertCompliance() noexcept;
   };
@@ -1028,7 +1042,7 @@ namespace FakeJni {
    using JClassBreeder<T, nullptr>::JClassBreeder;
 
    template<typename A>
-   static JObject * constructorPredicate(const JavaVM * vm, const char * signature, A args);
+   static JObject * constructorPredicate(const JavaVM * vm, const char * signature, A& args);
 
    static constexpr void assertCompliance() noexcept;
   };
@@ -1037,8 +1051,8 @@ namespace FakeJni {
  class JClass : public JObject {
  private:
   JObject
-   * (* const constructV)(const JavaVM *, const char *, va_list),
-   * (* const constructA)(const JavaVM *, const char *, const jvalue *);
+   * (* const constructV)(const JavaVM *, const char *, CX::va_list_t&),
+   * (* const constructA)(const JavaVM *, const char *, const jvalue *&);
 
   const char * const className;
 
@@ -1082,16 +1096,20 @@ namespace FakeJni {
   bool registerMethod(const JMethodID * mid) const;
   bool unregisterMethod(const JMethodID * mid) const noexcept;
   const JMethodID * getMethod(const char * sig, const char * name) const noexcept;
+  [[nodiscard]]
   const PointerList<const JMethodID *>& getMethods() const noexcept;
   bool registerField(JFieldID * fid) const noexcept;
   bool unregisterField(JFieldID * fid) const noexcept;
   const JFieldID * getField(const char * name) const noexcept;
   const JFieldID * getField(const char * sig, const char * name) const noexcept;
+  [[nodiscard]]
   const PointerList<const JFieldID *>& getFields() const noexcept;
   virtual const char * getName() const noexcept;
   //Object construction for c-varargs
-  JObject * newInstance(const JavaVM * vm, const char * signature, va_list list) const;
+  [[nodiscard]]
+  JObject * newInstance(const JavaVM * vm, const char * signature, CX::va_list_t& list) const;
   //Object construction for jvalue arrays
+  [[nodiscard]]
   JObject * newInstance(const JavaVM * vm, const char * signature, const jvalue * values) const;
  };
 
@@ -1473,7 +1491,7 @@ namespace FakeJni {
 
  //Performs virtual dispatch
  template<typename R, typename A>
- R JMethodID::virtualInvoke(const JavaVM * vm, void * clazzOrInst, A args) const {
+ R JMethodID::virtualInvoke(const JavaVM * vm, void * clazzOrInst, A& args) const {
   auto * clazz = &((JObject *)clazzOrInst)->getClass();
   if (strcmp(clazz->getName(), "java/lang/Class") == 0) {
    //Static method, no virtual dispatch
@@ -1512,7 +1530,7 @@ namespace FakeJni {
 
  //Does not perform virtual dispatch
  template<typename R, typename A>
- R JMethodID::nonVirtualInvoke(const JavaVM * vm, JClass * const clazz, void * const inst, A args) const {
+ R JMethodID::nonVirtualInvoke(const JavaVM * vm, JClass * const clazz, void * const inst, A& args) const {
   const auto mid = clazz->getMethod(signature, name);
   if (!mid) {
    throw std::runtime_error(
@@ -1528,13 +1546,13 @@ namespace FakeJni {
 
  template<typename R>
  R JMethodID::invoke(const JavaVM * const vm, const JObject * clazzOrInst, ...) const {
-  va_list list;
+  CX::va_list_t list;
   va_start(list, clazzOrInst);
   return internalInvoke<R>(vm, (void *)clazzOrInst, list);
  }
 
  template<typename R, typename A>
- R JMethodID::internalInvoke(const JavaVM * vm, void * clazzOrInst, A args) const {
+ R JMethodID::internalInvoke(const JavaVM * vm, void * clazzOrInst, A& args) const {
   using arg_t = typename CX::ComponentTypeResolver<A>::type;
   //used to reassemble functor object data
   using align_t = _CX::arbitrary_align_t<sizeof(std::function<void ()>)>;
@@ -1569,9 +1587,8 @@ namespace FakeJni {
      values[i + 2] = ((void * (*)(A))resolvers[i + resolverOffset])(args);
     }
 
-    //Would be CX::IsSame<T, va_list> but this comparison is not guaranteed
     //Copy all primitives or object pointers into values (va_list only, jvalue* is done above)
-    if constexpr (!CX::IsSame<arg_t, jvalue>::value) {
+    if constexpr (CX::IsSame<arg_t, CX::va_list_t>::value) {
      for (unsigned int i = 0; i < argc; i++) {
       const auto* ffi_arg_t = descriptor->arg_types[i + 2];
       _INTERNAL_INVOKE_VA_ARG(JByte, ffi_type_sint8)
@@ -1583,7 +1600,7 @@ namespace FakeJni {
       _INTERNAL_INVOKE_VA_ARG(JDouble, ffi_type_double)
 //      _INTERNAL_INVOKE_VA_ARG(JObject *, ffi_type_pointer)
       if (ffi_arg_t == &ffi_type_pointer) {
-       *((JObject **)values[i + 2]) = va_arg(args, JObject *);
+       *((JObject **)values[i + 2]) = CX::safe_va_arg<JObject *>(args);
        continue;
       }
      }
@@ -1680,7 +1697,7 @@ namespace FakeJni {
   //Class members
   template<typename T>
   template<typename A>
-  JObject * JClassBreeder<T, true>::constructorPredicate(const JavaVM * const vm, const char * const signature, A args) {
+  JObject * JClassBreeder<T, true>::constructorPredicate(const JavaVM * const vm, const char * const signature, A& args) {
    JClass& descriptor = const_cast<JClass&>(T::descriptor);
    Jvm * const jvm = (Jvm *)const_cast<JavaVM *>(vm);
    for (auto& method : descriptor.functions) {
@@ -1713,7 +1730,7 @@ namespace FakeJni {
   //Non-class members
   template<typename T>
   template<typename A>
-  JObject * JClassBreeder<T, false>::constructorPredicate(const JavaVM * vm, const char * signature, A args) {
+  JObject * JClassBreeder<T, false>::constructorPredicate(const JavaVM * vm, const char * signature, A& args) {
    throw std::runtime_error("FATAL: You cannot construct primitive types!");
    return nullptr;
   }
@@ -1768,8 +1785,8 @@ namespace FakeJni {
  template<typename T>
  JClass::JClass(uint32_t modifiers, _CX::JClassBreeder<T, true> breeder) noexcept :
   JObject(),
-  constructV(&decltype(breeder)::template constructorPredicate<va_list>),
-  constructA(&decltype(breeder)::template constructorPredicate<const jvalue *>),
+  constructV(&decltype(breeder)::template constructorPredicate<CX::va_list_t&>),
+  constructA(&decltype(breeder)::template constructorPredicate<const jvalue *&>),
   className(T::name),
   isArbitrary(false),
   modifiers(modifiers),
@@ -1785,8 +1802,8 @@ namespace FakeJni {
  template<typename T>
  JClass::JClass(uint32_t modifiers, _CX::JClassBreeder<T, false> breeder) noexcept :
   JObject(),
-  constructV(&decltype(breeder)::template constructorPredicate<va_list>),
-  constructA(&decltype(breeder)::template constructorPredicate<const jvalue *>),
+  constructV(&decltype(breeder)::template constructorPredicate<CX::va_list_t&>),
+  constructA(&decltype(breeder)::template constructorPredicate<const jvalue *&>),
   className(_CX::JniTypeBase<T>::signature),
   isArbitrary(false),
   modifiers(modifiers),

--- a/include/fake-jni/jvm.h
+++ b/include/fake-jni/jvm.h
@@ -1032,7 +1032,7 @@ namespace FakeJni {
    using JClassBreeder<T, nullptr>::JClassBreeder;
 
    template<typename A>
-   static JObject * constructorPredicate(const JavaVM * vm, const char * signature, A& args);
+   static JObject * constructorPredicate(const JavaVM * vm, const char * signature, A args);
 
    static constexpr void assertCompliance() noexcept;
   };
@@ -1042,7 +1042,7 @@ namespace FakeJni {
    using JClassBreeder<T, nullptr>::JClassBreeder;
 
    template<typename A>
-   static JObject * constructorPredicate(const JavaVM * vm, const char * signature, A& args);
+   static JObject * constructorPredicate(const JavaVM * vm, const char * signature, A args);
 
    static constexpr void assertCompliance() noexcept;
   };
@@ -1052,7 +1052,7 @@ namespace FakeJni {
  private:
   JObject
    * (* const constructV)(const JavaVM *, const char *, CX::va_list_t&),
-   * (* const constructA)(const JavaVM *, const char *, const jvalue *&);
+   * (* const constructA)(const JavaVM *, const char *, const jvalue *);
 
   const char * const className;
 
@@ -1697,7 +1697,7 @@ namespace FakeJni {
   //Class members
   template<typename T>
   template<typename A>
-  JObject * JClassBreeder<T, true>::constructorPredicate(const JavaVM * const vm, const char * const signature, A& args) {
+  JObject * JClassBreeder<T, true>::constructorPredicate(const JavaVM * const vm, const char * const signature, A args) {
    JClass& descriptor = const_cast<JClass&>(T::descriptor);
    Jvm * const jvm = (Jvm *)const_cast<JavaVM *>(vm);
    for (auto& method : descriptor.functions) {
@@ -1730,7 +1730,7 @@ namespace FakeJni {
   //Non-class members
   template<typename T>
   template<typename A>
-  JObject * JClassBreeder<T, false>::constructorPredicate(const JavaVM * vm, const char * signature, A& args) {
+  JObject * JClassBreeder<T, false>::constructorPredicate(const JavaVM * vm, const char * signature, A args) {
    throw std::runtime_error("FATAL: You cannot construct primitive types!");
    return nullptr;
   }
@@ -1786,7 +1786,7 @@ namespace FakeJni {
  JClass::JClass(uint32_t modifiers, _CX::JClassBreeder<T, true> breeder) noexcept :
   JObject(),
   constructV(&decltype(breeder)::template constructorPredicate<CX::va_list_t&>),
-  constructA(&decltype(breeder)::template constructorPredicate<const jvalue *&>),
+  constructA(&decltype(breeder)::template constructorPredicate<const jvalue *>),
   className(T::name),
   isArbitrary(false),
   modifiers(modifiers),
@@ -1803,7 +1803,7 @@ namespace FakeJni {
  JClass::JClass(uint32_t modifiers, _CX::JClassBreeder<T, false> breeder) noexcept :
   JObject(),
   constructV(&decltype(breeder)::template constructorPredicate<CX::va_list_t&>),
-  constructA(&decltype(breeder)::template constructorPredicate<const jvalue *&>),
+  constructA(&decltype(breeder)::template constructorPredicate<const jvalue *>),
   className(_CX::JniTypeBase<T>::signature),
   isArbitrary(false),
   modifiers(modifiers),

--- a/include/fake-jni/jvm.h
+++ b/include/fake-jni/jvm.h
@@ -1457,12 +1457,12 @@ namespace FakeJni {
    verifyName(name),
    verifySignature(_CX::SignatureGenerator<false, R, Args...>::signature),
    //low bytes of member pointer
-   CX::union_cast<_CX::member_ptr_align_t>(func).low
+   CX::union_cast<CX::member_ptr_align_t>(func).ptr
   },
   type(MEMBER_FUNC),
   modifiers(modifiers),
   //high bytes of member pointer
-  adj(CX::union_cast<_CX::member_ptr_align_t>(func).high),
+  adj(CX::union_cast<CX::member_ptr_align_t>(func).offset),
   proxyFuncV((void (*)())&_CX::FunctionAccessor<sizeof...(Args), decltype(func)>::template invokeV<>),
   proxyFuncA((void (*)())&_CX::FunctionAccessor<sizeof...(Args), decltype(func)>::template invokeA<>),
   isArbitrary(false)
@@ -1566,7 +1566,7 @@ namespace FakeJni {
     const auto proxy = (R (*)(void *const, member_func_t, A))getFunctionProxy<A>();
     return proxy(
      CX::union_cast<JObject *>(clazzOrInst),
-     CX::union_cast<member_func_t>(_CX::member_ptr_align_t{fnPtr, adj}),
+     CX::union_cast<member_func_t>(CX::member_ptr_align_t{fnPtr, adj}),
      args
     );
    }

--- a/src/fake-jni/jni/native/method.cpp
+++ b/src/fake-jni/jni/native/method.cpp
@@ -5,7 +5,7 @@ namespace FakeJni {
   return const_cast<JMethodID *>(((JClass *)*jclazz)->getMethod(sig, name));
  }
 
- jobject NativeInterface::callObjectMethodV(jobject const obj, jmethodID const mid, va_list list) const {
+ jobject NativeInterface::callObjectMethodV(jobject const obj, jmethodID const mid, CX::va_list_t& list) const {
   return ((JMethodID *)mid)->virtualInvoke<jobject>(&vm, obj, list);
  }
 
@@ -13,7 +13,7 @@ namespace FakeJni {
   return ((JMethodID *)mid)->virtualInvoke<jobject>(&vm, obj, args);
  }
 
- jboolean NativeInterface::callBooleanMethodV(jobject const obj, jmethodID const mid, va_list list) const {
+ jboolean NativeInterface::callBooleanMethodV(jobject const obj, jmethodID const mid, CX::va_list_t& list) const {
   return ((JMethodID *)mid)->virtualInvoke<jboolean>(&vm, obj, list);
  }
 
@@ -21,7 +21,7 @@ namespace FakeJni {
   return ((JMethodID *)mid)->virtualInvoke<jboolean>(&vm, obj, args);
  }
 
- jbyte NativeInterface::callByteMethodV(jobject const obj, jmethodID const mid, va_list list) const {
+ jbyte NativeInterface::callByteMethodV(jobject const obj, jmethodID const mid, CX::va_list_t& list) const {
   return ((JMethodID *)mid)->virtualInvoke<jbyte>(&vm, obj, list);
  }
 
@@ -29,7 +29,7 @@ namespace FakeJni {
   return ((JMethodID *)mid)->virtualInvoke<jbyte>(&vm, obj, args);
  }
 
- jchar NativeInterface::callCharMethodV(jobject const obj, jmethodID const mid, va_list list) const {
+ jchar NativeInterface::callCharMethodV(jobject const obj, jmethodID const mid, CX::va_list_t& list) const {
   return ((JMethodID *)mid)->virtualInvoke<jchar>(&vm, obj, list);
  }
 
@@ -37,7 +37,7 @@ namespace FakeJni {
   return ((JMethodID *)mid)->virtualInvoke<jchar>(&vm, obj, args);
  }
 
- jshort NativeInterface::callShortMethodV(jobject const obj, jmethodID const mid, va_list list) const {
+ jshort NativeInterface::callShortMethodV(jobject const obj, jmethodID const mid, CX::va_list_t& list) const {
   return ((JMethodID *)mid)->virtualInvoke<jshort>(&vm, obj, list);
  }
 
@@ -45,7 +45,7 @@ namespace FakeJni {
   return ((JMethodID *)mid)->virtualInvoke<jshort>(&vm, obj, args);
  }
 
- jint NativeInterface::callIntMethodV(jobject const obj, jmethodID const mid, va_list list) const {
+ jint NativeInterface::callIntMethodV(jobject const obj, jmethodID const mid, CX::va_list_t& list) const {
   return ((JMethodID *)mid)->virtualInvoke<jint>(&vm, obj, list);
  }
 
@@ -53,7 +53,7 @@ namespace FakeJni {
   return ((JMethodID *)mid)->virtualInvoke<jint>(&vm, obj, args);
  }
 
- jlong NativeInterface::callLongMethodV(jobject const obj, jmethodID const mid, va_list list) const {
+ jlong NativeInterface::callLongMethodV(jobject const obj, jmethodID const mid, CX::va_list_t& list) const {
   return ((JMethodID *)mid)->virtualInvoke<jlong>(&vm, obj, list);
  }
 
@@ -61,7 +61,7 @@ namespace FakeJni {
   return ((JMethodID *)mid)->virtualInvoke<jlong>(&vm, obj, args);
  }
 
- jfloat NativeInterface::callFloatMethodV(jobject const obj, jmethodID const mid, va_list list) const {
+ jfloat NativeInterface::callFloatMethodV(jobject const obj, jmethodID const mid, CX::va_list_t& list) const {
   return ((JMethodID *)mid)->virtualInvoke<jfloat>(&vm, obj, list);
  }
 
@@ -69,7 +69,7 @@ namespace FakeJni {
   return ((JMethodID *)mid)->virtualInvoke<jfloat>(&vm, obj, args);
  }
 
- jdouble NativeInterface::callDoubleMethodV(jobject const obj, jmethodID const mid, va_list list) const {
+ jdouble NativeInterface::callDoubleMethodV(jobject const obj, jmethodID const mid, CX::va_list_t& list) const {
   return ((JMethodID *)mid)->virtualInvoke<jdouble>(&vm, obj, list);
  }
 
@@ -77,7 +77,7 @@ namespace FakeJni {
   return ((JMethodID *)mid)->virtualInvoke<jdouble>(&vm, obj, args);
  }
 
- void NativeInterface::callVoidMethodV(jobject const obj, jmethodID const mid, va_list list) const {
+ void NativeInterface::callVoidMethodV(jobject const obj, jmethodID const mid, CX::va_list_t& list) const {
   ((JMethodID *)mid)->virtualInvoke<void>(&vm, obj, list);
  }
 
@@ -85,7 +85,7 @@ namespace FakeJni {
   ((JMethodID *)mid)->virtualInvoke<void>(&vm, obj, args);
  }
 
- jobject NativeInterface::callNonvirtualObjectMethodV(jobject const obj, jclass const clazz, jmethodID const mid, va_list list) const {
+ jobject NativeInterface::callNonvirtualObjectMethodV(jobject const obj, jclass const clazz, jmethodID const mid, CX::va_list_t& list) const {
   return ((JMethodID *)mid)->nonVirtualInvoke<jobject>(&vm, (JClass *)*clazz, obj, list);
  }
 
@@ -93,7 +93,7 @@ namespace FakeJni {
   return ((JMethodID *)mid)->nonVirtualInvoke<jobject>(&vm, (JClass *)*clazz, obj, args);
  }
 
- jboolean NativeInterface::callNonvirtualBooleanMethodV(jobject const obj, jclass const clazz, jmethodID const mid, va_list list) const {
+ jboolean NativeInterface::callNonvirtualBooleanMethodV(jobject const obj, jclass const clazz, jmethodID const mid, CX::va_list_t& list) const {
   return ((JMethodID *)mid)->nonVirtualInvoke<jboolean>(&vm, (JClass *)*clazz, obj, list);
  }
 
@@ -101,7 +101,7 @@ namespace FakeJni {
   return ((JMethodID *)mid)->nonVirtualInvoke<jboolean>(&vm, (JClass *)*clazz, obj, args);
  }
 
- jbyte NativeInterface::callNonvirtualByteMethodV(jobject const obj, jclass const clazz, jmethodID const mid, va_list list) const {
+ jbyte NativeInterface::callNonvirtualByteMethodV(jobject const obj, jclass const clazz, jmethodID const mid, CX::va_list_t& list) const {
   return ((JMethodID *)mid)->nonVirtualInvoke<jbyte>(&vm, (JClass *)*clazz, obj, list);
  }
 
@@ -109,7 +109,7 @@ namespace FakeJni {
   return ((JMethodID *)mid)->nonVirtualInvoke<jbyte>(&vm, (JClass *)*clazz, obj, args);
  }
 
- jchar NativeInterface::callNonvirtualCharMethodV(jobject const obj, jclass const clazz, jmethodID const mid, va_list list) const {
+ jchar NativeInterface::callNonvirtualCharMethodV(jobject const obj, jclass const clazz, jmethodID const mid, CX::va_list_t& list) const {
   return ((JMethodID *)mid)->nonVirtualInvoke<jchar>(&vm, (JClass *)*clazz, obj, list);
  }
 
@@ -117,7 +117,7 @@ namespace FakeJni {
   return ((JMethodID *)mid)->nonVirtualInvoke<jchar>(&vm, (JClass *)*clazz, obj, args);
  }
 
- jshort NativeInterface::callNonvirtualShortMethodV(jobject const obj, jclass const clazz, jmethodID const mid, va_list list) const {
+ jshort NativeInterface::callNonvirtualShortMethodV(jobject const obj, jclass const clazz, jmethodID const mid, CX::va_list_t& list) const {
   return ((JMethodID *)mid)->nonVirtualInvoke<jshort>(&vm, (JClass *)*clazz, obj, list);
  }
 
@@ -125,7 +125,7 @@ namespace FakeJni {
   return ((JMethodID *)mid)->nonVirtualInvoke<jshort>(&vm, (JClass *)*clazz, obj, args);
  }
 
- jint NativeInterface::callNonvirtualIntMethodV(jobject const obj, jclass const clazz, jmethodID const mid, va_list list) const {
+ jint NativeInterface::callNonvirtualIntMethodV(jobject const obj, jclass const clazz, jmethodID const mid, CX::va_list_t& list) const {
   return ((JMethodID *)mid)->nonVirtualInvoke<jint>(&vm, (JClass *)*clazz, obj, list);
  }
 
@@ -133,7 +133,7 @@ namespace FakeJni {
   return ((JMethodID *)mid)->nonVirtualInvoke<jint>(&vm, (JClass *)*clazz, obj, args);
  }
 
- jlong NativeInterface::callNonvirtualLongMethodV(jobject const obj, jclass const clazz, jmethodID const mid, va_list list) const {
+ jlong NativeInterface::callNonvirtualLongMethodV(jobject const obj, jclass const clazz, jmethodID const mid, CX::va_list_t& list) const {
   return ((JMethodID *)mid)->nonVirtualInvoke<jlong>(&vm, (JClass *)*clazz, obj, list);
  }
 
@@ -141,7 +141,7 @@ namespace FakeJni {
   return ((JMethodID *)mid)->nonVirtualInvoke<jlong>(&vm, (JClass *)*clazz, obj, args);
  }
 
- jfloat NativeInterface::callNonvirtualFloatMethodV(jobject const obj, jclass const clazz, jmethodID const mid, va_list list) const {
+ jfloat NativeInterface::callNonvirtualFloatMethodV(jobject const obj, jclass const clazz, jmethodID const mid, CX::va_list_t& list) const {
   return ((JMethodID *)mid)->nonVirtualInvoke<jfloat>(&vm, (JClass *)*clazz, obj, list);
  }
 
@@ -149,7 +149,7 @@ namespace FakeJni {
   return ((JMethodID *)mid)->nonVirtualInvoke<jfloat>(&vm, (JClass *)*clazz, obj, args);
  }
 
- jdouble NativeInterface::callNonvirtualDoubleMethodV(jobject const obj, jclass const clazz, jmethodID const mid, va_list list) const {
+ jdouble NativeInterface::callNonvirtualDoubleMethodV(jobject const obj, jclass const clazz, jmethodID const mid, CX::va_list_t& list) const {
   return ((JMethodID *)mid)->nonVirtualInvoke<jdouble>(&vm, (JClass *)*clazz, obj, list);
  }
 
@@ -157,7 +157,7 @@ namespace FakeJni {
   return ((JMethodID *)mid)->nonVirtualInvoke<jdouble>(&vm, (JClass *)*clazz, obj, args);
  }
 
- void NativeInterface::callNonvirtualVoidMethodV(jobject const obj, jclass const clazz, jmethodID const mid, va_list list) const {
+ void NativeInterface::callNonvirtualVoidMethodV(jobject const obj, jclass const clazz, jmethodID const mid, CX::va_list_t& list) const {
   ((JMethodID *)mid)->nonVirtualInvoke<void>(&vm, (JClass *)*clazz, obj, list);
  }
 
@@ -169,7 +169,7 @@ namespace FakeJni {
   return const_cast<JMethodID *>(((JClass *)*clazz)->getMethod(sig, name));
  }
 
- jobject NativeInterface::callStaticObjectMethodV(jclass const clazz, jmethodID const mid, va_list list) const {
+ jobject NativeInterface::callStaticObjectMethodV(jclass const clazz, jmethodID const mid, CX::va_list_t& list) const {
   return ((JMethodID *)mid)->virtualInvoke<jobject>(&vm, clazz, list);
  }
 
@@ -177,7 +177,7 @@ namespace FakeJni {
   return ((JMethodID *)mid)->virtualInvoke<jobject>(&vm, clazz, args);
  }
 
- jboolean NativeInterface::callStaticBooleanMethodV(jclass const clazz, jmethodID const mid, va_list list) const {
+ jboolean NativeInterface::callStaticBooleanMethodV(jclass const clazz, jmethodID const mid, CX::va_list_t& list) const {
   return ((JMethodID *)mid)->virtualInvoke<jboolean>(&vm, clazz, list);
  }
 
@@ -185,7 +185,7 @@ namespace FakeJni {
   return ((JMethodID *)mid)->virtualInvoke<jboolean>(&vm, clazz, args);
  }
 
- jbyte NativeInterface::callStaticByteMethodV(jclass const clazz, jmethodID const mid, va_list list) const {
+ jbyte NativeInterface::callStaticByteMethodV(jclass const clazz, jmethodID const mid, CX::va_list_t& list) const {
   return ((JMethodID *)mid)->virtualInvoke<jbyte>(&vm, clazz, list);
  }
 
@@ -193,7 +193,7 @@ namespace FakeJni {
   return ((JMethodID *)mid)->virtualInvoke<jbyte>(&vm, clazz, args);
  }
 
- jchar NativeInterface::callStaticCharMethodV(jclass clazz, jmethodID const mid, va_list list) const {
+ jchar NativeInterface::callStaticCharMethodV(jclass clazz, jmethodID const mid, CX::va_list_t& list) const {
   return ((JMethodID *)mid)->virtualInvoke<jchar>(&vm, clazz, list);
  }
 
@@ -201,7 +201,7 @@ namespace FakeJni {
   return ((JMethodID *)mid)->virtualInvoke<jchar>(&vm, clazz, args);
  }
 
- jshort NativeInterface::callStaticShortMethodV(jclass const clazz, jmethodID const mid, va_list list) const {
+ jshort NativeInterface::callStaticShortMethodV(jclass const clazz, jmethodID const mid, CX::va_list_t& list) const {
   return ((JMethodID *)mid)->virtualInvoke<jshort>(&vm, clazz, list);
  }
 
@@ -209,7 +209,7 @@ namespace FakeJni {
   return ((JMethodID *)mid)->virtualInvoke<jshort>(&vm, clazz, args);
  }
 
- jint NativeInterface::callStaticIntMethodV(jclass const clazz, jmethodID const mid, va_list list) const {
+ jint NativeInterface::callStaticIntMethodV(jclass const clazz, jmethodID const mid, CX::va_list_t& list) const {
   return ((JMethodID *)mid)->virtualInvoke<jint>(&vm, clazz, list);
  }
 
@@ -217,7 +217,7 @@ namespace FakeJni {
   return ((JMethodID *)mid)->virtualInvoke<jint>(&vm, clazz, args);
  }
 
- jlong NativeInterface::callStaticLongMethodV(jclass const clazz, jmethodID const mid, va_list list) const {
+ jlong NativeInterface::callStaticLongMethodV(jclass const clazz, jmethodID const mid, CX::va_list_t& list) const {
   return ((JMethodID *)mid)->virtualInvoke<jlong>(&vm, clazz, list);
  }
 
@@ -225,7 +225,7 @@ namespace FakeJni {
   return ((JMethodID *)mid)->virtualInvoke<jlong>(&vm, clazz, args);
  }
 
- jfloat NativeInterface::callStaticFloatMethodV(jclass const clazz, jmethodID const mid, va_list list) const {
+ jfloat NativeInterface::callStaticFloatMethodV(jclass const clazz, jmethodID const mid, CX::va_list_t& list) const {
   return ((JMethodID *)mid)->virtualInvoke<jfloat>(&vm, clazz, list);
  }
 
@@ -233,7 +233,7 @@ namespace FakeJni {
   return ((JMethodID *)mid)->virtualInvoke<jfloat>(&vm, clazz, args);
  }
 
- jdouble NativeInterface::callStaticDoubleMethodV(jclass const clazz, jmethodID const mid, va_list list) const {
+ jdouble NativeInterface::callStaticDoubleMethodV(jclass const clazz, jmethodID const mid, CX::va_list_t& list) const {
   return ((JMethodID *)mid)->virtualInvoke<jdouble>(&vm, clazz, list);
  }
 
@@ -241,7 +241,7 @@ namespace FakeJni {
   return ((JMethodID *)mid)->virtualInvoke<jdouble>(&vm, clazz, args);
  }
 
- void NativeInterface::callStaticVoidMethodV(jclass const clazz, jmethodID const mid, va_list list) const {
+ void NativeInterface::callStaticVoidMethodV(jclass const clazz, jmethodID const mid, CX::va_list_t& list) const {
   ((JMethodID *)mid)->virtualInvoke<void>(&vm, clazz, list);
  }
 

--- a/src/fake-jni/jni/native/native.cpp
+++ b/src/fake-jni/jni/native/native.cpp
@@ -135,7 +135,8 @@ namespace FakeJni {
   NewObjectV = [](JNIEnv *env, jclass clazz, jmethodID jmid, va_list l) -> jobject {
    _FETCH_JNI_ENV
    _NATIVE_DEBUG(NewObjectV)
-   return ni->newObjectV(clazz, jmid, l);
+   CX::va_list_t list = l;
+   return ni->newObjectV(clazz, jmid, list);
   };
   NewObjectA = [](JNIEnv *env, jclass clazz, jmethodID jmid, const jvalue *value) -> jobject {
    _FETCH_JNI_ENV
@@ -161,7 +162,8 @@ namespace FakeJni {
   CallObjectMethodV = [](JNIEnv *env, jobject obj, jmethodID jmid, va_list l) -> jobject {
    _FETCH_JNI_ENV
    _NATIVE_DEBUG(CallObjectMethodV)
-   return ni->callObjectMethodV(obj, jmid, l);
+   CX::va_list_t list = l;
+   return ni->callObjectMethodV(obj, jmid, list);
   };
   CallObjectMethodA = [](JNIEnv *env, jobject obj, jmethodID jmid, const jvalue *val) -> jobject {
    _FETCH_JNI_ENV
@@ -172,7 +174,8 @@ namespace FakeJni {
   CallBooleanMethodV = [](JNIEnv *env, jobject obj, jmethodID jmid, va_list l) -> jboolean {
    _FETCH_JNI_ENV
    _NATIVE_DEBUG(CallBooleanMethodV)
-   return ni->callBooleanMethodV(obj, jmid, l);
+   CX::va_list_t list = l;
+   return ni->callBooleanMethodV(obj, jmid, list);
   };
   CallBooleanMethodA = [](JNIEnv *env, jobject obj, jmethodID jmid, const jvalue *val) -> jboolean {
    _FETCH_JNI_ENV
@@ -183,7 +186,8 @@ namespace FakeJni {
   CallByteMethodV = [](JNIEnv *env, jobject obj, jmethodID jmid, va_list l) -> jbyte {
    _FETCH_JNI_ENV
    _NATIVE_DEBUG(CallByteMethodV)
-   return ni->callByteMethodV(obj, jmid, l);
+   CX::va_list_t list = l;
+   return ni->callByteMethodV(obj, jmid, list);
   };
   CallByteMethodA = [](JNIEnv *env, jobject obj, jmethodID jmid, const jvalue *val) -> jbyte {
    _FETCH_JNI_ENV
@@ -194,7 +198,8 @@ namespace FakeJni {
   CallCharMethodV = [](JNIEnv *env, jobject obj, jmethodID jmid, va_list l) -> jchar {
    _FETCH_JNI_ENV
    _NATIVE_DEBUG(CallCharMethodV)
-   return ni->callCharMethodV(obj, jmid, l);
+   CX::va_list_t list = l;
+   return ni->callCharMethodV(obj, jmid, list);
   };
   CallCharMethodA = [](JNIEnv *env, jobject obj, jmethodID jmid, const jvalue *val) -> jchar {
    _FETCH_JNI_ENV
@@ -205,7 +210,8 @@ namespace FakeJni {
   CallShortMethodV = [](JNIEnv *env, jobject obj, jmethodID jmid, va_list l) -> jshort {
    _FETCH_JNI_ENV
    _NATIVE_DEBUG(CallShortMethodV)
-   return ni->callShortMethodV(obj, jmid, l);
+   CX::va_list_t list = l;
+   return ni->callShortMethodV(obj, jmid, list);
   };
   CallShortMethodA = [](JNIEnv *env, jobject obj, jmethodID jmid, const jvalue *val) -> jshort {
    _FETCH_JNI_ENV
@@ -216,7 +222,8 @@ namespace FakeJni {
   CallIntMethodV = [](JNIEnv *env, jobject obj, jmethodID jmid, va_list l) -> jint {
    _FETCH_JNI_ENV
    _NATIVE_DEBUG(CallIntMethodV)
-   return ni->callIntMethodV(obj, jmid, l);
+   CX::va_list_t list = l;
+   return ni->callIntMethodV(obj, jmid, list);
   };
   CallIntMethodA = [](JNIEnv *env, jobject obj, jmethodID jmid, const jvalue *val) -> jint {
    _FETCH_JNI_ENV
@@ -227,7 +234,8 @@ namespace FakeJni {
   CallLongMethodV = [](JNIEnv *env, jobject obj, jmethodID jmid, va_list l) -> jlong {
    _FETCH_JNI_ENV
    _NATIVE_DEBUG(CallLongMethodV)
-   return ni->callLongMethodV(obj, jmid, l);
+   CX::va_list_t list = l;
+   return ni->callLongMethodV(obj, jmid, list);
   };
   CallLongMethodA = [](JNIEnv *env, jobject obj, jmethodID jmid, const jvalue *val) -> jlong {
    _FETCH_JNI_ENV
@@ -238,7 +246,8 @@ namespace FakeJni {
   CallFloatMethodV = [](JNIEnv *env, jobject obj, jmethodID jmid, va_list l) -> jfloat {
    _FETCH_JNI_ENV
    _NATIVE_DEBUG(CallFloatMethodV)
-   return ni->callFloatMethodV(obj, jmid, l);
+   CX::va_list_t list = l;
+   return ni->callFloatMethodV(obj, jmid, list);
   };
   CallFloatMethodA = [](JNIEnv *env, jobject obj, jmethodID jmid, const jvalue *val) -> jfloat {
    _FETCH_JNI_ENV
@@ -249,7 +258,8 @@ namespace FakeJni {
   CallDoubleMethodV = [](JNIEnv *env, jobject obj, jmethodID jmid, va_list l) -> jdouble {
    _FETCH_JNI_ENV
    _NATIVE_DEBUG(CallDoubleMethodV)
-   return ni->callDoubleMethodV(obj, jmid, l);
+   CX::va_list_t list = l;
+   return ni->callDoubleMethodV(obj, jmid, list);
   };
   CallDoubleMethodA = [](JNIEnv *env, jobject obj, jmethodID jmid, const jvalue *val) -> jdouble {
    _FETCH_JNI_ENV
@@ -260,7 +270,8 @@ namespace FakeJni {
   CallVoidMethodV = [](JNIEnv *env, jobject obj, jmethodID jmid, va_list l) -> void {
    _FETCH_JNI_ENV
    _NATIVE_DEBUG(CallVoidMethodV)
-   return ni->callVoidMethodV(obj, jmid, l);
+   CX::va_list_t list = l;
+   return ni->callVoidMethodV(obj, jmid, list);
   };
   CallVoidMethodA = [](JNIEnv *env, jobject obj, jmethodID jmid, const jvalue *val) -> void {
    _FETCH_JNI_ENV
@@ -271,7 +282,8 @@ namespace FakeJni {
   CallNonvirtualObjectMethodV = [](JNIEnv *env, jobject obj, jclass clazz, jmethodID jmid, va_list l) -> jobject {
    _FETCH_JNI_ENV
    _NATIVE_DEBUG(CallNonvirtualObjectMethodV)
-   return ni->callNonvirtualObjectMethodV(obj, clazz, jmid, l);
+   CX::va_list_t list = l;
+   return ni->callNonvirtualObjectMethodV(obj, clazz, jmid, list);
   };
   CallNonvirtualObjectMethodA = [](JNIEnv *env, jobject obj, jclass clazz, jmethodID jmid, const jvalue *val) -> jobject {
    _FETCH_JNI_ENV
@@ -282,7 +294,8 @@ namespace FakeJni {
   CallNonvirtualBooleanMethodV = [](JNIEnv *env, jobject obj, jclass clazz, jmethodID jmid, va_list l) -> jboolean {
    _FETCH_JNI_ENV
    _NATIVE_DEBUG(CallNonvirtualBooleanMethodV)
-   return ni->callNonvirtualBooleanMethodV(obj, clazz, jmid, l);
+   CX::va_list_t list = l;
+   return ni->callNonvirtualBooleanMethodV(obj, clazz, jmid, list);
   };
   CallNonvirtualBooleanMethodA = [](JNIEnv *env, jobject obj, jclass clazz, jmethodID jmid, const jvalue *val) -> jboolean {
    _FETCH_JNI_ENV
@@ -293,7 +306,8 @@ namespace FakeJni {
   CallNonvirtualByteMethodV = [](JNIEnv *env, jobject obj, jclass clazz, jmethodID jmid, va_list l) -> jbyte {
    _FETCH_JNI_ENV
    _NATIVE_DEBUG(CallNonvirtualByteMethodV)
-   return ni->callNonvirtualByteMethodV(obj, clazz, jmid, l);
+   CX::va_list_t list = l;
+   return ni->callNonvirtualByteMethodV(obj, clazz, jmid, list);
   };
   CallNonvirtualByteMethodA = [](JNIEnv *env, jobject obj, jclass clazz, jmethodID jmid, const jvalue *val) -> jbyte {
    _FETCH_JNI_ENV
@@ -304,7 +318,8 @@ namespace FakeJni {
   CallNonvirtualCharMethodV = [](JNIEnv *env, jobject obj, jclass clazz, jmethodID jmid, va_list l) -> jchar {
    _FETCH_JNI_ENV
    _NATIVE_DEBUG(CallNonvirtualCharMethodV)
-   return ni->callNonvirtualCharMethodV(obj, clazz, jmid, l);
+   CX::va_list_t list = l;
+   return ni->callNonvirtualCharMethodV(obj, clazz, jmid, list);
   };
   CallNonvirtualCharMethodA = [](JNIEnv *env, jobject obj, jclass clazz, jmethodID jmid, const jvalue *val) -> jchar {
    _FETCH_JNI_ENV
@@ -315,7 +330,8 @@ namespace FakeJni {
   CallNonvirtualShortMethodV = [](JNIEnv *env, jobject obj, jclass clazz, jmethodID jmid, va_list l) -> jshort {
    _FETCH_JNI_ENV
    _NATIVE_DEBUG(CallNonvirtualShortMethodV)
-   return ni->callNonvirtualShortMethodV(obj, clazz, jmid, l);
+   CX::va_list_t list = l;
+   return ni->callNonvirtualShortMethodV(obj, clazz, jmid, list);
   };
   CallNonvirtualShortMethodA = [](JNIEnv *env, jobject obj, jclass clazz, jmethodID jmid, const jvalue *val) -> jshort {
    _FETCH_JNI_ENV
@@ -326,7 +342,8 @@ namespace FakeJni {
   CallNonvirtualIntMethodV = [](JNIEnv *env, jobject obj, jclass clazz, jmethodID jmid, va_list l) -> jint {
    _FETCH_JNI_ENV
    _NATIVE_DEBUG(CallNonvirtualIntMethodV)
-   return ni->callNonvirtualIntMethodV(obj, clazz, jmid, l);
+   CX::va_list_t list = l;
+   return ni->callNonvirtualIntMethodV(obj, clazz, jmid, list);
   };
   CallNonvirtualIntMethodA = [](JNIEnv *env, jobject obj, jclass clazz, jmethodID jmid, const jvalue *val) -> jint {
    _FETCH_JNI_ENV
@@ -337,7 +354,8 @@ namespace FakeJni {
   CallNonvirtualLongMethodV = [](JNIEnv *env, jobject obj, jclass clazz, jmethodID jmid, va_list l) -> jlong {
    _FETCH_JNI_ENV
    _NATIVE_DEBUG(CallNonvirtualLongMethodV)
-   return ni->callNonvirtualLongMethodV(obj, clazz, jmid, l);
+   CX::va_list_t list = l;
+   return ni->callNonvirtualLongMethodV(obj, clazz, jmid, list);
   };
   CallNonvirtualLongMethodA = [](JNIEnv *env, jobject obj, jclass clazz, jmethodID jmid, const jvalue *val) -> jlong {
    _FETCH_JNI_ENV
@@ -348,7 +366,8 @@ namespace FakeJni {
   CallNonvirtualFloatMethodV = [](JNIEnv *env, jobject obj, jclass clazz, jmethodID jmid, va_list l) -> jfloat {
    _FETCH_JNI_ENV
    _NATIVE_DEBUG(CallNonvirtualFloatMethodV)
-   return ni->callNonvirtualFloatMethodV(obj, clazz, jmid, l);
+   CX::va_list_t list = l;
+   return ni->callNonvirtualFloatMethodV(obj, clazz, jmid, list);
   };
   CallNonvirtualFloatMethodA = [](JNIEnv *env, jobject obj, jclass clazz, jmethodID jmid, const jvalue *val) -> jfloat {
    _FETCH_JNI_ENV
@@ -359,7 +378,8 @@ namespace FakeJni {
   CallNonvirtualDoubleMethodV = [](JNIEnv *env, jobject obj, jclass clazz, jmethodID jmid, va_list l) -> jdouble {
    _FETCH_JNI_ENV
    _NATIVE_DEBUG(CallNonvirtualDoubleMethodV)
-   return ni->callNonvirtualDoubleMethodV(obj, clazz, jmid, l);
+   CX::va_list_t list = l;
+   return ni->callNonvirtualDoubleMethodV(obj, clazz, jmid, list);
   };
   CallNonvirtualDoubleMethodA = [](JNIEnv *env, jobject obj, jclass clazz, jmethodID jmid, const jvalue *val) -> jdouble {
    _FETCH_JNI_ENV
@@ -370,7 +390,8 @@ namespace FakeJni {
   CallNonvirtualVoidMethodV = [](JNIEnv *env, jobject obj, jclass clazz, jmethodID jmid, va_list l) -> void {
    _FETCH_JNI_ENV
    _NATIVE_DEBUG(CallNonvirtualVoidMethodV)
-   return ni->callNonvirtualVoidMethodV(obj, clazz, jmid, l);
+   CX::va_list_t list = l;
+   return ni->callNonvirtualVoidMethodV(obj, clazz, jmid, list);
   };
   CallNonvirtualVoidMethodA = [](JNIEnv *env, jobject obj, jclass clazz, jmethodID jmid, const jvalue *val) -> void {
    _FETCH_JNI_ENV
@@ -481,7 +502,8 @@ namespace FakeJni {
   CallStaticObjectMethodV = [](JNIEnv *env, jclass clazz, jmethodID jmid, va_list l) -> jobject {
    _FETCH_JNI_ENV
    _NATIVE_DEBUG(CallStaticObjectMethodV)
-   return ni->callStaticObjectMethodV(clazz, jmid, l);
+   CX::va_list_t list = l;
+   return ni->callStaticObjectMethodV(clazz, jmid, list);
   };
   CallStaticObjectMethodA = [](JNIEnv *env, jclass clazz, jmethodID jmid, const jvalue *val) -> jobject {
    _FETCH_JNI_ENV
@@ -492,7 +514,8 @@ namespace FakeJni {
   CallStaticBooleanMethodV = [](JNIEnv *env, jclass clazz, jmethodID jmid, va_list l) -> jboolean {
    _FETCH_JNI_ENV
    _NATIVE_DEBUG(CallStaticBooleanMethodV)
-   return ni->callStaticBooleanMethodV(clazz, jmid, l);
+   CX::va_list_t list = l;
+   return ni->callStaticBooleanMethodV(clazz, jmid, list);
   };
   CallStaticBooleanMethodA = [](JNIEnv *env, jclass clazz, jmethodID jmid, const jvalue *val) -> jboolean {
    _FETCH_JNI_ENV
@@ -503,7 +526,8 @@ namespace FakeJni {
   CallStaticByteMethodV = [](JNIEnv *env, jclass clazz, jmethodID jmid, va_list l) -> jbyte {
    _FETCH_JNI_ENV
    _NATIVE_DEBUG(CallStaticByteMethodV)
-   return ni->callStaticByteMethodV(clazz, jmid, l);
+   CX::va_list_t list = l;
+   return ni->callStaticByteMethodV(clazz, jmid, list);
   };
   CallStaticByteMethodA = [](JNIEnv *env, jclass clazz, jmethodID jmid, const jvalue *val) -> jbyte {
    _FETCH_JNI_ENV
@@ -514,7 +538,8 @@ namespace FakeJni {
   CallStaticCharMethodV = [](JNIEnv *env, jclass clazz, jmethodID jmid, va_list l) -> jchar {
    _FETCH_JNI_ENV
    _NATIVE_DEBUG(CallStaticCharMethodV)
-   return ni->callStaticCharMethodV(clazz, jmid, l);
+   CX::va_list_t list = l;
+   return ni->callStaticCharMethodV(clazz, jmid, list);
   };
   CallStaticCharMethodA = [](JNIEnv *env, jclass clazz, jmethodID jmid, const jvalue *val) -> jchar {
    _FETCH_JNI_ENV
@@ -525,7 +550,8 @@ namespace FakeJni {
   CallStaticShortMethodV = [](JNIEnv *env, jclass clazz, jmethodID jmid, va_list l) -> jshort {
    _FETCH_JNI_ENV
    _NATIVE_DEBUG(CallStaticShortMethodV)
-   return ni->callStaticShortMethodV(clazz, jmid, l);
+   CX::va_list_t list = l;
+   return ni->callStaticShortMethodV(clazz, jmid, list);
   };
   CallStaticShortMethodA = [](JNIEnv *env, jclass clazz, jmethodID jmid, const jvalue *val) -> jshort {
    _FETCH_JNI_ENV
@@ -536,7 +562,8 @@ namespace FakeJni {
   CallStaticIntMethodV = [](JNIEnv *env, jclass clazz, jmethodID jmid, va_list l) -> jint {
    _FETCH_JNI_ENV
    _NATIVE_DEBUG(CallStaticIntMethodV)
-   return ni->callStaticIntMethodV(clazz, jmid, l);
+   CX::va_list_t list = l;
+   return ni->callStaticIntMethodV(clazz, jmid, list);
   };
   CallStaticIntMethodA = [](JNIEnv *env, jclass clazz, jmethodID jmid, const jvalue *val) -> jint {
    _FETCH_JNI_ENV
@@ -547,7 +574,8 @@ namespace FakeJni {
   CallStaticLongMethodV = [](JNIEnv *env, jclass clazz, jmethodID jmid, va_list l) -> jlong {
    _FETCH_JNI_ENV
    _NATIVE_DEBUG(CallStaticLongMethodV)
-   return ni->callStaticLongMethodV(clazz, jmid, l);
+   CX::va_list_t list = l;
+   return ni->callStaticLongMethodV(clazz, jmid, list);
   };
   CallStaticLongMethodA = [](JNIEnv *env, jclass clazz, jmethodID jmid, const jvalue *val) -> jlong {
    _FETCH_JNI_ENV
@@ -558,7 +586,8 @@ namespace FakeJni {
   CallStaticFloatMethodV = [](JNIEnv *env, jclass clazz, jmethodID jmid, va_list l) -> jfloat {
    _FETCH_JNI_ENV
    _NATIVE_DEBUG(CallStaticFloatMethodV)
-   return ni->callStaticFloatMethodV(clazz, jmid, l);
+   CX::va_list_t list = l;
+   return ni->callStaticFloatMethodV(clazz, jmid, list);
   };
   CallStaticFloatMethodA = [](JNIEnv *env, jclass clazz, jmethodID jmid, const jvalue *val) -> jfloat {
    _FETCH_JNI_ENV
@@ -569,7 +598,8 @@ namespace FakeJni {
   CallStaticDoubleMethodV = [](JNIEnv *env, jclass clazz, jmethodID jmid, va_list l) -> jdouble {
    _FETCH_JNI_ENV
    _NATIVE_DEBUG(CallStaticDoubleMethodV)
-   return ni->callStaticDoubleMethodV(clazz, jmid, l);
+   CX::va_list_t list = l;
+   return ni->callStaticDoubleMethodV(clazz, jmid, list);
   };
   CallStaticDoubleMethodA = [](JNIEnv *env, jclass clazz, jmethodID jmid, const jvalue *val) -> jdouble {
    _FETCH_JNI_ENV
@@ -580,7 +610,8 @@ namespace FakeJni {
   CallStaticVoidMethodV = [](JNIEnv *env, jclass clazz, jmethodID jmid, va_list l) -> void {
    _FETCH_JNI_ENV
    _NATIVE_DEBUG(CallStaticVoidMethodV)
-   return ni->callStaticVoidMethodV(clazz, jmid, l);
+   CX::va_list_t list = l;
+   return ni->callStaticVoidMethodV(clazz, jmid, list);
   };
   CallStaticVoidMethodA = [](JNIEnv *env, jclass clazz, jmethodID jmid, const jvalue *val) -> void {
    _FETCH_JNI_ENV

--- a/src/fake-jni/jni/native/native_vararg.cpp
+++ b/src/fake-jni/jni/native/native_vararg.cpp
@@ -1,8 +1,10 @@
 #include "fake-jni/internal/jni/native.h"
 #include "fake-jni/jvm.h"
 
+#include <cx/vararg.h>
+
 #define _BEGIN_VA_LIST \
-va_list l;\
+CX::va_list_t l;\
 va_start(l, jmid);
 
 namespace FakeJni {

--- a/src/fake-jni/jni/native/object.cpp
+++ b/src/fake-jni/jni/native/object.cpp
@@ -13,7 +13,7 @@ namespace FakeJni {
   return nullptr;
  }
 
- jobject NativeInterface::newObjectV(jclass clazz, jmethodID mid, va_list args) const {
+ jobject NativeInterface::newObjectV(jclass clazz, jmethodID mid, CX::va_list_t& args) const {
   return *((JClass *)*clazz)->newInstance(&vm, ((JMethodID *)mid)->getSignature(), args);
  }
 

--- a/src/fake-jni/jvm/class.cpp
+++ b/src/fake-jni/jvm/class.cpp
@@ -11,7 +11,7 @@ namespace FakeJni {
   constructV([](const JavaVM * const, const char * const, CX::va_list_t&) -> JObject * {
    _ERROR_ARBITRARY_CLASS
   }),
-  constructA([](const JavaVM * const, const char * const, const jvalue *&) -> JObject * {
+  constructA([](const JavaVM * const, const char * const, const jvalue *) -> JObject * {
    _ERROR_ARBITRARY_CLASS
   }),
   className(name),

--- a/src/fake-jni/jvm/class.cpp
+++ b/src/fake-jni/jvm/class.cpp
@@ -8,10 +8,10 @@ throw std::runtime_error("FATAL: Cannot construct an arbitrary class with no nat
 namespace FakeJni {
  JClass::JClass(const char *name, uint32_t modifiers) noexcept :
   JObject(),
-  constructV([](const JavaVM * const, const char * const, va_list) -> JObject * {
+  constructV([](const JavaVM * const, const char * const, CX::va_list_t&) -> JObject * {
    _ERROR_ARBITRARY_CLASS
   }),
-  constructA([](const JavaVM * const, const char * const, const jvalue *) -> JObject * {
+  constructA([](const JavaVM * const, const char * const, const jvalue *&) -> JObject * {
    _ERROR_ARBITRARY_CLASS
   }),
   className(name),
@@ -148,11 +148,11 @@ namespace FakeJni {
   return className;
  }
 
- JObject * JClass::newInstance(const JavaVM * const vm, const char * const signature, va_list list) const {
+ JObject * JClass::newInstance(const JavaVM * const vm, const char * const signature, CX::va_list_t& list) const {
   return constructV(vm, signature, list);
  }
 
- JObject * JClass::newInstance(const JavaVM * const vm, const char * const signature, const jvalue * const values) const {
+ JObject * JClass::newInstance(const JavaVM * const vm, const char * const signature, const jvalue * values) const {
   return constructA(vm, signature, values);
  }
 }

--- a/src/fake-jni/jvm/method.cpp
+++ b/src/fake-jni/jvm/method.cpp
@@ -166,7 +166,7 @@ namespace FakeJni {
    auto& descriptor = pair.second;
    if (!descriptor) {
     auto&& args = getFfiPrototype(signature, name);
-    const auto argc = (unsigned int)args.size() - 2;
+    const auto argc = (unsigned int)args.size() - 1;
     descriptor = new ffi_cif;
     auto types = new ffi_type*[argc + 2];
     //env type
@@ -177,7 +177,7 @@ namespace FakeJni {
     for (unsigned int i = 0; i < argc; i++) {
      types[i + 2] = args[i];
     }
-    auto status = ffi_prep_cif(descriptor, FFI_DEFAULT_ABI, argc + 2, args[argc + 1], types);
+    auto status = ffi_prep_cif(descriptor, FFI_DEFAULT_ABI, argc + 2, args[argc], types);
     if (status != FFI_OK) {
      throw std::runtime_error(
       "FATAL: ffi_prep_cif failed for function: '"
@@ -213,12 +213,12 @@ namespace FakeJni {
    auto& descriptor = pair.second;
    if (!descriptor) {
     auto&& args = getFfiPrototype(signature, name);
-    const auto argc = (unsigned int)args.size() - 2;
+    const auto argc = (unsigned int)args.size() - 1;
     descriptor = new ffi_cif;
     auto types = new ffi_type*[2];
     types[0] = &ffi_type_pointer;
     types[1] = &ffi_type_pointer;
-    auto status = ffi_prep_cif_var(descriptor, FFI_DEFAULT_ABI, 2, argc + 2, args[argc + 1], types);
+    auto status = ffi_prep_cif_var(descriptor, FFI_DEFAULT_ABI, 2, argc + 2, args[argc], types);
     if (status != FFI_OK) {
      throw std::runtime_error(
       "FATAL: ffi_prep_cif_var failed for function: '"

--- a/src/fake-jni/jvm/method.cpp
+++ b/src/fake-jni/jvm/method.cpp
@@ -1,6 +1,7 @@
 #include "fake-jni/jvm.h"
 
 #include <cx/tuple.h>
+#include <cx/vararg.h>
 
 #include <ffi.h>
 
@@ -28,7 +29,7 @@ throw std::runtime_error("FATAL: Could not parse signature for native method: '"
 #define RESOLVER_CASE(a_type, ffi_type) \
 if (type == &ffi_type) {\
  return CX::Tuple<void (*)(), void (*)(), void (*)()> {\
-  (void (*)())&NativeInvocationManager<a_type>::allocate<va_list>,\
+  (void (*)())&NativeInvocationManager<a_type>::allocate<CX::va_list_t&>,\
   (void (*)())&NativeInvocationManager<a_type>::allocate<jvalue *>,\
   (void (*)())&NativeInvocationManager<a_type>::deallocate\
  };\
@@ -50,7 +51,7 @@ struct NativeInvocationManager {
  static void * allocate(ListType);
 
  template<>
- static void * allocate<va_list>(va_list list) {
+ static void * allocate<CX::va_list_t&>(CX::va_list_t& list) {
   return new Arg;
  }
 
@@ -85,11 +86,6 @@ static auto typeResolverGenerator(ffi_type * const type) {
 //Non-template members of JMethodID
 namespace FakeJni {
  std::map<size_t, std::pair<unsigned long, ffi_cif *>> JMethodID::descriptors;
-
- template<>
- inline JMethodID::static_func_t JMethodID::getFunctionProxy<const jvalue *>() const {
-  return proxyFuncA;
- }
 
  //TODO
  char * JMethodID::verifyName(const char * name) {


### PR DESCRIPTION
This branch introduces a seamless and portable abstraction overtop the builtin c-vararg api, which can perform static type analysis for argument retrieval as well as guarantee type safety and consistent functionality for the [`CX::va_list_t`](https://github.com/Matthewacon/CX/blob/master/cx/vararg.h#L112) type, which cannot be guaranteed for `va_list` (defined in [`cstdarg`](http://www.cplusplus.com/reference/cstdarg/)) due to its implementation specific type signature.

Along with these changes comes code elimination, as with reference semantics, subsequent invocations to `CX::safe_va_arg<T>`, or `va_X` macros that mutate state, are guaranteed to modify the principal object. That being said, should you chose not to use reference semantics, the wrapper will be copy-constructed along with the trivially constructable implementation of `va_list`, causing you to run into the same issues that would arise when using the default `va_list` implementation, wherein you modify a local instance and encounter UB when modifying the principal instance, out of scope.